### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/leanneknott/6746272d-b9c3-4a91-bf8a-9eef900a1114/3e9e94f4-b990-49f6-9177-046bee5174af/_apis/work/boardbadge/5c9318c3-9d76-47d6-b8c6-9421630f6195)](https://dev.azure.com/leanneknott/6746272d-b9c3-4a91-bf8a-9eef900a1114/_boards/board/t/3e9e94f4-b990-49f6-9177-046bee5174af/Microsoft.RequirementCategory)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.sothree.slidinguppanel/library/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.sothree.slidinguppanel/library)
 [![Badge](http://www.libtastic.com/static/osbadges/30.png)](http://www.libtastic.com/technology/30/)
 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#2](https://dev.azure.com/leanneknott/6746272d-b9c3-4a91-bf8a-9eef900a1114/_workitems/edit/2). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.